### PR TITLE
Fix condition where worker picks up job before job state commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ commands:
   bundle_install_and_test:
     steps:
       - checkout
-      - run: sudo gem update --system
+      - run: gem install bundler -v 2.1.4
       - run: bundle install
       - run: bundle exec rubocop
       - run: bundle exec appraisal install


### PR DESCRIPTION
This state was in particular hit when the enqueue happened in a
transaction. The job would be enqueued before the transaction
was commited. This would then cause an issue where the find would fail,
we would wait at the create call due to the lock from the insertion on
the enqueue callback, then fail due to violating the uniqueness
constraint.

This effectively emulates the logic behind #create_or_find_by, but is
more liberal in what cases fall back so we can continue to use our model
validation on the uniqueness constraint.