### PR TITLE
BREAKING CHANGE: Change state transition method to match names of state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
       - run: bundle exec appraisal install
       - run:
           name: Wait for DB
-          command: dockerize -wait tcp://127.0.0.1:3307 -timeout 1m
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 1m
       - run: bundle exec appraisal rspec --format progress --format RspecJunitFormatter --out spec_results/rspec.xml
       - store_test_results:
           path: spec_results
@@ -21,16 +21,12 @@ jobs:
     docker:
       - image: circleci/ruby:2.6.3
       - image: circleci/mysql:5.7
-        environment:
-          MYSQL_TCP_PORT: 3307
   test-ruby-271:
     steps:
       - bundle_install_and_test
     docker:
       - image: circleci/ruby:2.7.1
       - image: circleci/mysql:5.7
-        environment:
-          MYSQL_TCP_PORT: 3307
 
 workflows:
   rc:

--- a/lib/ae_active_job_state/has_job_state.rb
+++ b/lib/ae_active_job_state/has_job_state.rb
@@ -36,12 +36,12 @@ module AeActiveJobState
           @job_state = AeActiveJobState::JobState.find_by!(active_job_id: job.job_id)
         end
 
-        job_state.run!
+        job_state.running!
         job_state.reload
         block.call
-        job_state.finish!
+        job_state.finished!
       rescue StandardError => e
-        @job_state.fail!
+        @job_state.failed!
         raise e
       end
     end

--- a/lib/ae_active_job_state/job_state.rb
+++ b/lib/ae_active_job_state/job_state.rb
@@ -14,18 +14,18 @@ module AeActiveJobState
       state :finished
       state :failed
 
-      event :run do
-        transitions from: %w[pending failed], to: :running
+      event :running do
+        transitions to: :running
         after { update!(started_at: Time.now) }
       end
 
-      event :fail do
-        transitions from: :running, to: :failed
+      event :failed do
+        transitions to: :failed
         after { update!(failed_at: Time.now) }
       end
 
-      event :finish do
-        transitions from: :running, to: :finished
+      event :finished do
+        transitions to: :finished
         after { update!(finished_at: Time.now) }
       end
     end

--- a/spec/ae_active_job_state/job_state_spec.rb
+++ b/spec/ae_active_job_state/job_state_spec.rb
@@ -24,20 +24,20 @@ describe AeActiveJobState::JobState, type: %i[model] do
     end
 
     it 'sets started_at when it runs' do
-      js.run!
+      js.running!
       expect(js.reload).to have_attributes(started_at: be_present, failed_at: nil, finished_at: nil, status: 'running')
     end
 
     it 'sets finished_at when it finishes' do
-      js.run!
-      js.finish!
+      js.running!
+      js.finished!
       expect(js.reload).to have_attributes(started_at: be_present, failed_at: nil, finished_at: be_present,
                                            status: 'finished')
     end
 
     it 'sets failed_at when it fails' do
-      js.run!
-      js.fail!
+      js.running!
+      js.failed
       expect(js.reload).to have_attributes(started_at: be_present, failed_at: be_present, finished_at: nil,
                                            status: 'failed')
     end

--- a/spec/setup_db.rb
+++ b/spec/setup_db.rb
@@ -12,8 +12,7 @@ ActiveRecord::Base.configurations = {
     database: 'ae_active_job_state_test',
     username: 'root',
     host: '127.0.0.1',
-    encoding: 'utf8mb4',
-    port: 3307        # assume that Mysql 5.6 runs at port 3306 and 5.7 runs at port 3307
+    encoding: 'utf8mb4'
   }
 }
 ActiveRecord::Base.logger = Logger.new(File.join('log', 'test.log'))


### PR DESCRIPTION
Also ignore previous state when changing to new state. We have observed a few cases of race condition that make these state update comes from unexpected states. I don't care enough to catch those errors.