### PR TITLE
update the timestamp of the events in same SQL statement with state transition

### DIFF
--- a/lib/ae_active_job_state/job_state.rb
+++ b/lib/ae_active_job_state/job_state.rb
@@ -15,18 +15,15 @@ module AeActiveJobState
       state :failed
 
       event :running do
-        transitions to: :running
-        after { update!(started_at: Time.now) }
+        transitions to: :running, after: -> { self.started_at = Time.now }
       end
 
       event :failed do
-        transitions to: :failed
-        after { update!(failed_at: Time.now) }
+        transitions to: :failed, after: -> { self.failed_at = Time.now }
       end
 
       event :finished do
-        transitions to: :finished
-        after { update!(finished_at: Time.now) }
+        transitions to: :finished, after: -> { self.finished_at = Time.now }
       end
     end
   end

--- a/spec/ae_active_job_state/job_state_spec.rb
+++ b/spec/ae_active_job_state/job_state_spec.rb
@@ -37,7 +37,7 @@ describe AeActiveJobState::JobState, type: %i[model] do
 
     it 'sets failed_at when it fails' do
       js.running!
-      js.failed
+      js.failed!
       expect(js.reload).to have_attributes(started_at: be_present, failed_at: be_present, finished_at: nil,
                                            status: 'failed')
     end


### PR DESCRIPTION
Old:

> UPDATE `ae_active_job_state_job_states` SET `ae_active_job_state_job_states`.`updated_at` = '2021-06-21 17:24:22.076344', `ae_active_job_state_job_states`.`status` = 'running' WHERE `ae_active_job_state_job_states`.`id` = 1
> UPDATE `ae_active_job_state_job_states` SET `ae_active_job_state_job_states`.`updated_at` = '2021-06-21 17:24:22.079012', `ae_active_job_state_job_states`.`started_at` = '2021-06-21 17:24:22' WHERE `ae_active_job_state_job_states`.`id` = 1

New:

> UPDATE `ae_active_job_state_job_states` SET `ae_active_job_state_job_states`.`updated_at` = '2021-06-21 17:27:17.601070', `ae_active_job_state_job_states`.`status` = 'running', `ae_active_job_state_job_states`.`started_at` = '2021-06-21 17:27:17' WHERE `ae_active_job_state_job_states`.`id` = 1