### PR TITLE
Standardize CI and test configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - master
+    paths:
+      - 'ae_active_job_state.gemspec'
+      - 'lib/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `paths:` filters to release.yml so releases only trigger on gem-relevant file changes
- Update `minitest-reporters` constraint to `>= 1.8, < 2`
- Set `Rake::TestTask` verbose to false

[BANK-2077](https://appfolio.atlassian.net/browse/BANK-2077)

[BANK-2077]: https://appfolio.atlassian.net/browse/BANK-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ