### PR TITLE
[BANK-2106] Migrate gem source from RubyGems to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   gem-tool: appfolio/gem-tool@volatile
+  public-packages: https://raw.githubusercontent.com/appfolio/public-packages/v1/orbs/public-packages.yml
 
 workflows:
   rc:
@@ -15,6 +16,8 @@ workflows:
                 - '4.0.1'
                 - '3.4.8'
                 - '3.3.10'
+          after-checkout-steps:
+            - public-packages/setup
           after-appraisal-install-steps:
             - gem-tool/wait_mysql
             - run: bundle exec rubocop

--- a/Appraisals
+++ b/Appraisals
@@ -5,19 +5,19 @@ unless Gem::Requirement.new(['>= 3.3', '< 4.1']).satisfied_by?(Gem::Version.new(
 end
 
 appraise "ruby-#{RUBY_VERSION}_rails72" do
-  source 'https://rubygems.org' do
+  source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_active_job_state-gem/' do
     gem 'rails', '~> 7.2.0'
   end
 end
 
 appraise "ruby-#{RUBY_VERSION}_rails80" do
-  source 'https://rubygems.org' do
+  source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_active_job_state-gem/' do
     gem 'rails', '~> 8.0.0'
   end
 end
 
 appraise "ruby-#{RUBY_VERSION}_rails81" do
-  source 'https://rubygems.org' do
+  source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_active_job_state-gem/' do
     gem 'rails', '~> 8.1.0'
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' # global source
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_active_job_state-gem/' # global source
 
-source 'https://rubygems.org' do
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_active_job_state-gem/' do
   gem 'appraisal', '>= 2.5', '< 3'
   gem 'bundler', '>= 2.6', '< 5'
   gem 'debug', '>= 1.11', '< 2'


### PR DESCRIPTION
## Summary
Migrate Ruby gem source from rubygems.org to JFrog as part of org-wide JFrog migration.

## Changes
- Replaced `source 'https://rubygems.org'` with JFrog URL in Gemfile (global and block sources)
- Replaced `source 'https://rubygems.org'` with JFrog URL in Appraisals
- Updated `allowed_push_host` in gemspec to JFrog URL
- Added `public-packages` orb and `after-checkout-steps` to CircleCI config for JFrog authentication
- Created `.github/dependabot.yaml` with JFrog registry configuration

## Why
AppFolio is migrating from RubyGems.org to JFrog for Ruby dependency installation.
Jira Issue: https://appfolio.atlassian.net/browse/BANK-2106

## Test Plan
- CI passes with the new gem source configuration